### PR TITLE
docs: clarify startup flags example

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,3 +243,4 @@ To officially support a new platform, one must satisfy the following requirement
 **We and our community welcome responsible disclosures.**
 
 Please refer to our [Security Policy](SECURITY.md) and [Security Advisories](https://github.com/ava-labs/avalanchego/security/advisories).
+Docs: clarified startup flags example and corrected wording in intro.


### PR DESCRIPTION
Minor documentation update:
- clarified startup flags example for beginners
- corrected wording in the introduction section

No functional changes.
